### PR TITLE
Resolve build warnings in console.fsproj

### DIFF
--- a/console/console.fsproj
+++ b/console/console.fsproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="../lib/lib.fsproj" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
Resolves https://github.com/dotnet/sdk/issues/2721

You need this reference in your console application because the SDK does not currently flow Microsoft.AspNetCore.App transitively across ProjectReferences.